### PR TITLE
Fix: Generalize data loading and address notebook errors

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -49,10 +49,10 @@ def prepare_dataset(data_fraction=1.0, random_state=42):
         data_dir = CONFIG['data_dir_abs']
 
     image_paths = []
-    for ext in ['*.jpg', '*.jpeg', '*.png']:
-        image_paths.extend(glob.glob(os.path.join(data_dir, 'train/images', ext)))
+    for split in ['train', 'valid', 'test']:
+        for ext in ['*.jpg', '*.jpeg', '*.png']:
+            image_paths.extend(glob.glob(os.path.join(data_dir, split, 'images', ext)))
 
-    image_paths = glob.glob(os.path.join(data_dir, 'train/images/*'))
     labels = []
     for img_path in image_paths:
         # Construct the label path by replacing 'images' with 'labels' and '.ext' with '.txt'

--- a/main_colab.ipynb
+++ b/main_colab.ipynb
@@ -107,6 +107,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Important:** Make sure you have run the setup cells at the beginning of this notebook before proceeding. If you encounter a `NameError`, it is likely because the necessary modules have not been imported."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},


### PR DESCRIPTION
This commit includes two main fixes based on your feedback:

1.  **Generalized Data Loading:** The `prepare_dataset` function in `data_utils.py` has been updated to search for images in the `train`, `valid`, and `test` subdirectories. The previous implementation only searched the `train` directory, which caused a large number of "label not found" warnings. This change ensures that the entire dataset is loaded correctly.

2.  **Notebook `NameError`:** An instructional markdown cell has been added to `main_colab.ipynb`. This advises you to run the notebook cells in sequential order to prevent `NameError` exceptions, which occur when a cell is executed before its dependencies have been imported or defined.