### PR TITLE
Fix: Correctly apply epoch override for resumable training

### DIFF
--- a/main_colab.ipynb
+++ b/main_colab.ipynb
@@ -80,6 +80,7 @@
     "}\n",
     "CONFIG['model']['frozen_layers'] = training_overrides.get('frozen_layers', CONFIG['model']['frozen_layers'])\n",
     "CONFIG['training']['data_fraction'] = training_overrides.get('data_fraction', CONFIG['training']['data_fraction'])\n",
+    "CONFIG['training']['epochs'] = training_overrides.get('epochs', CONFIG['training']['epochs'])\n",
     "\n",
     "# Prepare the dataset\n",
     "image_paths, labels = prepare_dataset(CONFIG['training']['data_fraction'])\n",


### PR DESCRIPTION
This commit fixes a bug in `main_colab.ipynb` where the user-defined number of epochs was not being correctly applied when `resume_training` was enabled.

Previously, the `CONFIG['training']['epochs']` value was not being updated from the `training_overrides` dictionary. This caused the training loop to terminate prematurely when resuming from a checkpoint, as it would always see the original epoch count from the config file.

The fix adds the necessary line to update the `epochs` value in the `CONFIG` dictionary at runtime, ensuring that the trainer will continue training up to the new, user-specified number of epochs.